### PR TITLE
新增通过`Lifecycle`处理反注册

### DIFF
--- a/slidebacklib/build.gradle
+++ b/slidebacklib/build.gradle
@@ -21,4 +21,9 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    compileOnly 'androidx.appcompat:appcompat:1.1.0'
+    // Lifecycles
+    def lifecycle_version = "2.2.0"
+    compileOnly "androidx.lifecycle:lifecycle-runtime:$lifecycle_version"
+    compileOnly "androidx.lifecycle:lifecycle-common-java8:$lifecycle_version"
 }


### PR DESCRIPTION
如果调用方 `Activity` 为 `ComponentActivity` 的子类，则无需显式调用 `unregisterSlideBack` 方法